### PR TITLE
Remove allocations when computing next generation

### DIFF
--- a/board.go
+++ b/board.go
@@ -1,9 +1,10 @@
 package main
 
 type board struct {
-	cells         [][]bool
-	generation    int
-	width, height int
+	currentGenCells [][]bool
+	nextGenCells    [][]bool
+	generation      int
+	width, height   int
 }
 
 func (b *board) ifAlive(x, y int) int {
@@ -11,7 +12,7 @@ func (b *board) ifAlive(x, y int) int {
 		return 0
 	}
 
-	if b.cells[y][x] {
+	if b.currentGenCells[y][x] {
 		return 1
 	}
 
@@ -36,40 +37,32 @@ func (b *board) countNeighbours(x, y int) int {
 }
 
 func (b *board) nextGen() {
-	state := b.computeNextGen()
+	b.computeNextGen()
 	b.generation++
 
-	for y := 0; y < b.height; y++ {
-		for x := 0; x < b.width; x++ {
-			b.cells[y][x] = state[y][x]
-		}
-	}
+	b.currentGenCells, b.nextGenCells = b.nextGenCells, b.currentGenCells
 }
 
-func (b *board) computeNextGen() [][]bool {
-	state := make([][]bool, b.height)
-
+func (b *board) computeNextGen() {
 	for y := 0; y < b.height; y++ {
-		state[y] = make([]bool, b.width)
-
 		for x := 0; x < b.width; x++ {
 			n := b.countNeighbours(x, y)
 
-			if b.cells[y][x] {
-				state[y][x] = n == 2 || n == 3
+			if b.currentGenCells[y][x] {
+				b.nextGenCells[y][x] = n == 2 || n == 3
 			} else {
-				state[y][x] = n == 3
+				b.nextGenCells[y][x] = n == 3
 			}
 		}
 	}
-
-	return state
 }
 
 func (b *board) createGrid(w, h int) {
-	b.cells = make([][]bool, h)
+	b.currentGenCells = make([][]bool, h)
+	b.nextGenCells = make([][]bool, h)
 	for y := 0; y < h; y++ {
-		b.cells[y] = make([]bool, w)
+		b.currentGenCells[y] = make([]bool, w)
+		b.nextGenCells[y] = make([]bool, w)
 	}
 
 	b.width = w
@@ -85,16 +78,19 @@ func (b *board) ensureGridSize(w, h int) {
 
 	if xDelta > 0 {
 		// extend existing rows
-		for i, row := range b.cells {
-			b.cells[i] = append(row, make([]bool, xDelta)...)
+		for y := 0; y < b.height; y++ {
+			b.currentGenCells[y] = append(b.currentGenCells[y], make([]bool, xDelta)...)
+			b.nextGenCells[y] = append(b.nextGenCells[y], make([]bool, xDelta)...)
 		}
 	}
 
 	if yDelta > 0 {
 		// add empty rows
-		b.cells = append(b.cells, make([][]bool, yDelta)...)
+		b.currentGenCells = append(b.currentGenCells, make([][]bool, yDelta)...)
+		b.nextGenCells = append(b.nextGenCells, make([][]bool, yDelta)...)
 		for y := b.height; y < h; y++ {
-			b.cells[y] = make([]bool, w)
+			b.currentGenCells[y] = make([]bool, w)
+			b.nextGenCells[y] = make([]bool, w)
 		}
 	}
 
@@ -104,56 +100,56 @@ func (b *board) ensureGridSize(w, h int) {
 
 func (b *board) load() {
 	// gun
-	b.cells[5][1] = true
-	b.cells[5][2] = true
-	b.cells[6][1] = true
-	b.cells[6][2] = true
+	b.currentGenCells[5][1] = true
+	b.currentGenCells[5][2] = true
+	b.currentGenCells[6][1] = true
+	b.currentGenCells[6][2] = true
 
-	b.cells[3][13] = true
-	b.cells[3][14] = true
-	b.cells[4][12] = true
-	b.cells[4][16] = true
-	b.cells[5][11] = true
-	b.cells[5][17] = true
-	b.cells[6][11] = true
-	b.cells[6][15] = true
-	b.cells[6][17] = true
-	b.cells[6][18] = true
-	b.cells[7][11] = true
-	b.cells[7][17] = true
-	b.cells[8][12] = true
-	b.cells[8][16] = true
-	b.cells[9][13] = true
-	b.cells[9][14] = true
+	b.currentGenCells[3][13] = true
+	b.currentGenCells[3][14] = true
+	b.currentGenCells[4][12] = true
+	b.currentGenCells[4][16] = true
+	b.currentGenCells[5][11] = true
+	b.currentGenCells[5][17] = true
+	b.currentGenCells[6][11] = true
+	b.currentGenCells[6][15] = true
+	b.currentGenCells[6][17] = true
+	b.currentGenCells[6][18] = true
+	b.currentGenCells[7][11] = true
+	b.currentGenCells[7][17] = true
+	b.currentGenCells[8][12] = true
+	b.currentGenCells[8][16] = true
+	b.currentGenCells[9][13] = true
+	b.currentGenCells[9][14] = true
 
-	b.cells[1][25] = true
-	b.cells[2][23] = true
-	b.cells[2][25] = true
-	b.cells[3][21] = true
-	b.cells[3][22] = true
-	b.cells[4][21] = true
-	b.cells[4][22] = true
-	b.cells[5][21] = true
-	b.cells[5][22] = true
-	b.cells[6][23] = true
-	b.cells[6][25] = true
-	b.cells[7][25] = true
+	b.currentGenCells[1][25] = true
+	b.currentGenCells[2][23] = true
+	b.currentGenCells[2][25] = true
+	b.currentGenCells[3][21] = true
+	b.currentGenCells[3][22] = true
+	b.currentGenCells[4][21] = true
+	b.currentGenCells[4][22] = true
+	b.currentGenCells[5][21] = true
+	b.currentGenCells[5][22] = true
+	b.currentGenCells[6][23] = true
+	b.currentGenCells[6][25] = true
+	b.currentGenCells[7][25] = true
 
-	b.cells[3][35] = true
-	b.cells[3][36] = true
-	b.cells[4][35] = true
-	b.cells[4][36] = true
+	b.currentGenCells[3][35] = true
+	b.currentGenCells[3][36] = true
+	b.currentGenCells[4][35] = true
+	b.currentGenCells[4][36] = true
 
 	// spaceship
-	b.cells[34][2] = true
-	b.cells[34][3] = true
-	b.cells[34][4] = true
-	b.cells[34][5] = true
-	b.cells[35][1] = true
-	b.cells[35][5] = true
-	b.cells[36][5] = true
-	b.cells[37][1] = true
-	b.cells[37][4] = true
+	b.currentGenCells[34][2] = true
+	b.currentGenCells[34][3] = true
+	b.currentGenCells[34][4] = true
+	b.currentGenCells[34][5] = true
+	b.currentGenCells[35][1] = true
+	b.currentGenCells[35][5] = true
+	b.currentGenCells[36][5] = true
+	b.currentGenCells[37][1] = true
+	b.currentGenCells[37][4] = true
 }
 
 func newBoard(minX, minY int) *board {

--- a/board.go
+++ b/board.go
@@ -7,17 +7,14 @@ type board struct {
 }
 
 func (b *board) ifAlive(x, y int) int {
-	if x < 0 || x >= b.width {
-		return 0
-	}
-
-	if y < 0 || y >= b.height {
+	if x < 0 || x >= b.width || y < 0 || y >= b.height {
 		return 0
 	}
 
 	if b.cells[y][x] {
 		return 1
 	}
+
 	return 0
 }
 

--- a/board_test.go
+++ b/board_test.go
@@ -58,10 +58,11 @@ func TestBoard_EnsureGridSize(t *testing.T) {
 	assert.True(t, b.currentGenCells[1][1])
 }
 
-func TestBoard_Generatoin(t *testing.T) {
-	b := &board{}
-	b.createGrid(5, 5)
+func TestBoard_Generation(t *testing.T) {
+	b := newBoard(5, 5)
 	assert.Equal(t, 0, b.generation)
+	assert.Equal(t, b.height, b.width)
+	assert.Equal(t, 5, b.height)
 
 	b.nextGen()
 	assert.Equal(t, 1, b.generation)

--- a/board_test.go
+++ b/board_test.go
@@ -9,10 +9,10 @@ import (
 func TestBoard_CountNeighbours(t *testing.T) {
 	b := &board{}
 	b.createGrid(3, 3)
-	b.cells[0][0] = true
-	b.cells[0][2] = true
-	b.cells[2][0] = true
-	b.cells[2][2] = true
+	b.currentGenCells[0][0] = true
+	b.currentGenCells[0][2] = true
+	b.currentGenCells[2][0] = true
+	b.currentGenCells[2][2] = true
 
 	assert.Equal(t, 4, b.countNeighbours(1, 1))
 }
@@ -20,9 +20,9 @@ func TestBoard_CountNeighbours(t *testing.T) {
 func TestBoard_CountNeighbours_Corner(t *testing.T) {
 	b := &board{}
 	b.createGrid(2, 2)
-	b.cells[0][1] = true
-	b.cells[1][0] = true
-	b.cells[1][1] = true
+	b.currentGenCells[0][1] = true
+	b.currentGenCells[1][0] = true
+	b.currentGenCells[1][1] = true
 
 	assert.Equal(t, 3, b.countNeighbours(0, 0))
 }
@@ -32,7 +32,7 @@ func TestBoard_CountNeighbours_IgnoresMiddle(t *testing.T) {
 	b.createGrid(3, 3)
 	for y := 0; y < 3; y++ {
 		for x := 0; x < 3; x++ {
-			b.cells[y][x] = true
+			b.currentGenCells[y][x] = true
 		}
 	}
 
@@ -43,19 +43,19 @@ func TestBoard_CreateGrid(t *testing.T) {
 	b := &board{}
 	b.createGrid(5, 3)
 
-	assert.Equal(t, 3, len(b.cells))
-	assert.Equal(t, 5, len(b.cells[0]))
+	assert.Equal(t, 3, len(b.currentGenCells))
+	assert.Equal(t, 5, len(b.currentGenCells[0]))
 }
 
 func TestBoard_EnsureGridSize(t *testing.T) {
 	b := &board{}
 	b.createGrid(2, 2)
-	b.cells[1][1] = true
+	b.currentGenCells[1][1] = true
 
 	b.ensureGridSize(4, 4)
-	assert.Equal(t, 4, len(b.cells))
-	assert.Equal(t, 4, len(b.cells[0]))
-	assert.True(t, b.cells[1][1])
+	assert.Equal(t, 4, len(b.currentGenCells))
+	assert.Equal(t, 4, len(b.currentGenCells[0]))
+	assert.True(t, b.currentGenCells[1][1])
 }
 
 func TestBoard_Generatoin(t *testing.T) {
@@ -65,4 +65,27 @@ func TestBoard_Generatoin(t *testing.T) {
 
 	b.nextGen()
 	assert.Equal(t, 1, b.generation)
+}
+
+func BenchmarkBoard_NextGeneration(b *testing.B) {
+	board := &board{}
+	board.createGrid(15, 16)
+
+	// 0x0
+	board.currentGenCells[6][7] = true
+
+	// x0x
+	// x0x
+	board.currentGenCells[7][6] = true
+	board.currentGenCells[7][8] = true
+	board.currentGenCells[8][6] = true
+	board.currentGenCells[8][8] = true
+
+	// 0x0
+	board.currentGenCells[9][7] = true
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		board.nextGen()
+	}
 }

--- a/game.go
+++ b/game.go
@@ -64,7 +64,7 @@ func (g *gameRenderer) draw(w, h int) image.Image {
 
 	for y := 0; y < pixH; y++ {
 		for x := 0; x < pixW; x++ {
-			if x < g.game.board.width && y < g.game.board.height && g.game.board.cells[y][x] {
+			if x < g.game.board.width && y < g.game.board.height && g.game.board.currentGenCells[y][x] {
 				img.Set(x, y, g.aliveColor)
 			} else {
 				img.Set(x, y, g.deadColor)
@@ -136,7 +136,7 @@ func (g *game) Tapped(ev *fyne.PointEvent) {
 		return
 	}
 
-	g.board.cells[ypos][xpos] = !g.board.cells[ypos][xpos]
+	g.board.currentGenCells[ypos][xpos] = !g.board.currentGenCells[ypos][xpos]
 
 	g.Refresh()
 }


### PR DESCRIPTION
This is partly based on https://github.com/fyne-io/life/pull/3. My testing showed the code was faster without making it concurrent due to the overhead of creating goroutines making it slower. This applies the change to remove allocations (I made sure to add @MatejMagat305 as a co-author).

Benchmark results from this change (and one with concurrency for the sake of it):
```
goos: linux
goarch: amd64
pkg: github.com/fyne-io/life
cpu: Intel(R) Core(TM) i7-8650U CPU @ 1.90GHz
BenchmarkBoard_NextGenerationOld-8   	     	     	  258802	      4496 ns/op	     640 B/op	      17 allocs/op
BenchmarkBoard_NextGenerationNew-8   	     	     	  265190	      3804 ns/op	       0 B/op	       0 allocs/op
BenchmarkBoard_NextGenerationNew+Concurrent-8   	  150158	      7771 ns/op	      16 B/op	       1 allocs/op
PASS
ok  	github.com/fyne-io/life	1.067s
```